### PR TITLE
Add general OCR endpoint with Textract

### DIFF
--- a/excel_to_json/settings.py
+++ b/excel_to_json/settings.py
@@ -42,7 +42,11 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'api', 'rest_framework','pdfconvert']
+    'api',
+    'rest_framework',
+    'pdfconvert',
+    'ocr',
+]  
 
 REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': [

--- a/excel_to_json/urls.py
+++ b/excel_to_json/urls.py
@@ -18,6 +18,8 @@ from django.contrib import admin
 from django.urls import path, include
 
 urlpatterns = [
-    path('admin/', admin.site.urls),path('api/', include ('api.urls')),
+    path('admin/', admin.site.urls),
+    path('api/', include('api.urls')),
     path('api/pdf/', include('pdfconvert.urls')),
+    path('api/ocr/', include('ocr.urls')),
 ]

--- a/ocr/__init__.py
+++ b/ocr/__init__.py
@@ -1,0 +1,3 @@
+from .parsers import TextractOCRParser
+__all__ = ['TextractOCRParser']
+

--- a/ocr/apps.py
+++ b/ocr/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+class OcrConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'ocr'

--- a/ocr/parsers.py
+++ b/ocr/parsers.py
@@ -5,8 +5,9 @@ import time
 
 class TextractOCRParser:
     """Extract plain text from PDFs using Amazon Textract"""
+
     def __init__(self, bucket: str | None = None):
-        self.bucket = bucket or os.getenv("TEXTRACT_S3_BUCKET")
+        self.bucket = bucket or os.getenv('TEXTRACT_S3_BUCKET')
         self._client = None
         self._s3 = None
 
@@ -17,7 +18,7 @@ class TextractOCRParser:
                 'textract',
                 aws_access_key_id=os.getenv('AWS_ACCESS_KEY_ID'),
                 aws_secret_access_key=os.getenv('AWS_SECRET_ACCESS_KEY'),
-                region_name="us-east-2"
+                region_name='us-east-2'
             )
         return self._client
 
@@ -28,14 +29,14 @@ class TextractOCRParser:
                 's3',
                 aws_access_key_id=os.getenv('AWS_ACCESS_KEY_ID'),
                 aws_secret_access_key=os.getenv('AWS_SECRET_ACCESS_KEY'),
-                region_name="us-east-2"
+                region_name='us-east-2'
             )
         return self._s3
 
     def parse(self, file_obj):
         data = file_obj.read()
         if not self.bucket:
-            raise ValueError("TEXTRACT_S3_BUCKET not configured")
+            raise ValueError('TEXTRACT_S3_BUCKET not configured')
 
         key = f"textract_ocr/{uuid.uuid4()}.pdf"
         self.s3.put_object(Bucket=self.bucket, Key=key, Body=data)
@@ -53,7 +54,7 @@ class TextractOCRParser:
                 resp = self.client.get_document_text_detection(JobId=job_id)
             status = resp.get('JobStatus')
             if status == 'FAILED':
-                raise RuntimeError(f"Textract job {job_id} failed")
+                raise RuntimeError(f'Textract job {job_id} failed')
             blocks.extend(resp.get('Blocks', []))
             next_token = resp.get('NextToken')
             if status == 'SUCCEEDED' and not next_token:
@@ -63,4 +64,4 @@ class TextractOCRParser:
         self.s3.delete_object(Bucket=self.bucket, Key=key)
 
         lines = [b['Text'] for b in blocks if b.get('BlockType') == 'LINE']
-        return {"text": "\n".join(lines)}
+        return {'text': '\n'.join(lines)}

--- a/ocr/urls.py
+++ b/ocr/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+from .views import TextractOCRView
+
+app_name = 'ocr'
+
+urlpatterns = [
+    path('textract/', TextractOCRView.as_view(), name='textract'),
+]

--- a/ocr/views.py
+++ b/ocr/views.py
@@ -1,0 +1,30 @@
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+from rest_framework.parsers import MultiPartParser
+
+from .parsers import TextractOCRParser
+
+class TextractOCRView(APIView):
+    """Return plain text extracted from a PDF using Amazon Textract."""
+    parser_classes = [MultiPartParser]
+
+    def post(self, request, *args, **kwargs):
+        file = request.FILES.get('file')
+        if not file:
+            return Response(
+                {"error": "Archivo no proporcionado", "detail": "Se requiere el campo 'file'"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        parser = TextractOCRParser()
+        try:
+            payload = parser.parse(file)
+        except Exception as e:
+            print(">>> OCR TEXTRACT ERROR:", e)
+            return Response(
+                {"error": "Error al procesar el archivo", "detail": str(e)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        return Response(payload, status=status.HTTP_200_OK)

--- a/pdfconvert/parsers/__init__.py
+++ b/pdfconvert/parsers/__init__.py
@@ -4,7 +4,6 @@ from .bogota import ParserBogota
 from .davivienda import ParserDavivienda
 from .casa_bolsa import ParserCasaBolsa
 from .textract import TextractParser
-from .ocr_textract import TextractOCRParser
 __all__ = [
     "PlainTextParser",
     "ParserBancolombia",
@@ -12,5 +11,5 @@ __all__ = [
     "ParserDavivienda",
     "ParserCasaBolsa",
     "TextractParser",
-    "TextractOCRParser",
 ]
+

--- a/pdfconvert/parsers/__init__.py
+++ b/pdfconvert/parsers/__init__.py
@@ -4,6 +4,7 @@ from .bogota import ParserBogota
 from .davivienda import ParserDavivienda
 from .casa_bolsa import ParserCasaBolsa
 from .textract import TextractParser
+from .ocr_textract import TextractOCRParser
 __all__ = [
     "PlainTextParser",
     "ParserBancolombia",
@@ -11,4 +12,5 @@ __all__ = [
     "ParserDavivienda",
     "ParserCasaBolsa",
     "TextractParser",
+    "TextractOCRParser",
 ]

--- a/pdfconvert/parsers/ocr_textract.py
+++ b/pdfconvert/parsers/ocr_textract.py
@@ -1,0 +1,66 @@
+import boto3
+import os
+import uuid
+import time
+
+class TextractOCRParser:
+    """Extract plain text from PDFs using Amazon Textract"""
+    def __init__(self, bucket: str | None = None):
+        self.bucket = bucket or os.getenv("TEXTRACT_S3_BUCKET")
+        self._client = None
+        self._s3 = None
+
+    @property
+    def client(self):
+        if self._client is None:
+            self._client = boto3.client(
+                'textract',
+                aws_access_key_id=os.getenv('AWS_ACCESS_KEY_ID'),
+                aws_secret_access_key=os.getenv('AWS_SECRET_ACCESS_KEY'),
+                region_name="us-east-2"
+            )
+        return self._client
+
+    @property
+    def s3(self):
+        if self._s3 is None:
+            self._s3 = boto3.client(
+                's3',
+                aws_access_key_id=os.getenv('AWS_ACCESS_KEY_ID'),
+                aws_secret_access_key=os.getenv('AWS_SECRET_ACCESS_KEY'),
+                region_name="us-east-2"
+            )
+        return self._s3
+
+    def parse(self, file_obj):
+        data = file_obj.read()
+        if not self.bucket:
+            raise ValueError("TEXTRACT_S3_BUCKET not configured")
+
+        key = f"textract_ocr/{uuid.uuid4()}.pdf"
+        self.s3.put_object(Bucket=self.bucket, Key=key, Body=data)
+
+        start = self.client.start_document_text_detection(
+            DocumentLocation={'S3Object': {'Bucket': self.bucket, 'Name': key}}
+        )
+        job_id = start['JobId']
+        next_token = None
+        blocks = []
+        while True:
+            if next_token:
+                resp = self.client.get_document_text_detection(JobId=job_id, NextToken=next_token)
+            else:
+                resp = self.client.get_document_text_detection(JobId=job_id)
+            status = resp.get('JobStatus')
+            if status == 'FAILED':
+                raise RuntimeError(f"Textract job {job_id} failed")
+            blocks.extend(resp.get('Blocks', []))
+            next_token = resp.get('NextToken')
+            if status == 'SUCCEEDED' and not next_token:
+                break
+            time.sleep(1)
+
+        self.s3.delete_object(Bucket=self.bucket, Key=key)
+
+        lines = [b['Text'] for b in blocks if b.get('BlockType') == 'LINE']
+        return {"text": "\n".join(lines)}

--- a/pdfconvert/urls.py
+++ b/pdfconvert/urls.py
@@ -1,6 +1,6 @@
 # pdfconvert/urls.py
 from django.urls import path
-from .views import PDFConvertView, PDFTextractView, TextractOCRView
+from .views import PDFConvertView, PDFTextractView
 
 app_name = 'pdfconvert'
 
@@ -8,6 +8,5 @@ urlpatterns = [
     # fijas el parámetro bank_key en la propia ruta:
 path('convert/<str:bank_key>/', PDFConvertView.as_view(), name='convert_pdf'),
 path('convert_textract/<str:bank_key>/', PDFTextractView.as_view(), name='convert_pdf_textract'),
-path('ocr_textract/', TextractOCRView.as_view(), name='ocr_textract'),
 
 ]

--- a/pdfconvert/urls.py
+++ b/pdfconvert/urls.py
@@ -1,6 +1,6 @@
 # pdfconvert/urls.py
 from django.urls import path
-from .views import PDFConvertView,PDFTextractView
+from .views import PDFConvertView, PDFTextractView, TextractOCRView
 
 app_name = 'pdfconvert'
 
@@ -8,5 +8,6 @@ urlpatterns = [
     # fijas el parámetro bank_key en la propia ruta:
 path('convert/<str:bank_key>/', PDFConvertView.as_view(), name='convert_pdf'),
 path('convert_textract/<str:bank_key>/', PDFTextractView.as_view(), name='convert_pdf_textract'),
+path('ocr_textract/', TextractOCRView.as_view(), name='ocr_textract'),
 
 ]

--- a/pdfconvert/views.py
+++ b/pdfconvert/views.py
@@ -5,7 +5,6 @@ from rest_framework          import status
 
 from pdfconvert.parsers.plaintext import PlainTextParser
 from pdfconvert.registry          import get_handler
-from pdfconvert.parsers.ocr_textract import TextractOCRParser
 from rest_framework.parsers import MultiPartParser
 
 
@@ -88,26 +87,3 @@ class PDFTextractView(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
-class TextractOCRView(APIView):
-    """Return plain text extracted from a PDF using Amazon Textract."""
-    parser_classes = [MultiPartParser]
-
-    def post(self, request, *args, **kwargs):
-        file = request.FILES.get('file')
-        if not file:
-            return Response(
-                {"error": "Archivo no proporcionado", "detail": "Se requiere el campo 'file'"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        parser = TextractOCRParser()
-        try:
-            payload = parser.parse(file)
-        except Exception as e:
-            print(">>> OCR TEXTRACT ERROR:", e)
-            return Response(
-                {"error": "Error al procesar el archivo", "detail": str(e)},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        return Response(payload, status=status.HTTP_200_OK)

--- a/pdfconvert/views.py
+++ b/pdfconvert/views.py
@@ -5,6 +5,7 @@ from rest_framework          import status
 
 from pdfconvert.parsers.plaintext import PlainTextParser
 from pdfconvert.registry          import get_handler
+from pdfconvert.parsers.ocr_textract import TextractOCRParser
 from rest_framework.parsers import MultiPartParser
 
 
@@ -85,3 +86,28 @@ class PDFTextractView(APIView):
             return Response(payload, status=status.HTTP_200_OK)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+class TextractOCRView(APIView):
+    """Return plain text extracted from a PDF using Amazon Textract."""
+    parser_classes = [MultiPartParser]
+
+    def post(self, request, *args, **kwargs):
+        file = request.FILES.get('file')
+        if not file:
+            return Response(
+                {"error": "Archivo no proporcionado", "detail": "Se requiere el campo 'file'"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        parser = TextractOCRParser()
+        try:
+            payload = parser.parse(file)
+        except Exception as e:
+            print(">>> OCR TEXTRACT ERROR:", e)
+            return Response(
+                {"error": "Error al procesar el archivo", "detail": str(e)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        return Response(payload, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Summary
- support extracting plain text from PDFs using AWS Textract
- expose new `ocr_textract/` route for OCR

## Testing
- `python -m py_compile pdfconvert/parsers/ocr_textract.py`
- `python -m py_compile pdfconvert/views.py`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685eeebb5de48330a8bb361a1742a2a2