### PR TITLE
Add receipt extraction for OCR text

### DIFF
--- a/ocr/views.py
+++ b/ocr/views.py
@@ -4,6 +4,37 @@ from rest_framework import status
 from rest_framework.parsers import MultiPartParser
 
 from .parsers import TextractOCRParser
+import re
+
+
+def _extract_receipts(text: str) -> list[dict]:
+    """Parse Textract plain text into structured receipt data."""
+    pattern = re.compile(
+        r"(\d{1,2} de [A-Za-záéíóúÁÉÍÓÚ]+ del \d{4}|[A-Za-záéíóúÁÉÍÓÚ]+ del \d{4})"
+        r".*?DEBE A:\s*(.*?)\nLa suma.*?TOTAL\n\$?\.?\s*(\d+[\.,]\d+)",
+        re.IGNORECASE | re.DOTALL,
+    )
+
+    receipts: list[dict] = []
+    for match in pattern.finditer(text):
+        fecha = match.group(1).strip()
+        debe_a = match.group(2).strip()
+        total = match.group(3).strip()
+
+        block = match.group(0)
+        turnos_nums = re.findall(r"\n(\d+)\n\d{2}/\d{2}/\d{4}", block)
+        turnos = max(map(int, turnos_nums)) if turnos_nums else None
+
+        receipts.append(
+            {
+                "fecha": fecha,
+                "DEBE A": debe_a,
+                "Turnos": turnos,
+                "total": total,
+            }
+        )
+
+    return receipts
 
 class TextractOCRView(APIView):
     """Return plain text extracted from a PDF using Amazon Textract."""
@@ -26,5 +57,7 @@ class TextractOCRView(APIView):
                 {"error": "Error al procesar el archivo", "detail": str(e)},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+        text = payload.get("text", "")
+        data = _extract_receipts(text)
 
-        return Response(payload, status=status.HTTP_200_OK)
+        return Response({"results": data}, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Summary
- parse OCR output with regex to extract receipt data
- return structured information from `TextractOCRView`

## Testing
- `flake8 || true`
- `python manage.py test` *(fails: Django missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ef9fa8e3083309b2f7ad90e913242