### PR TITLE
Implement Express-style login in Django

### DIFF
--- a/excel_to_json/urls.py
+++ b/excel_to_json/urls.py
@@ -22,6 +22,9 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', include('api.urls')),
     path('api/auth/', include('authapp.urls')),
+    # Provide a top-level login endpoint for convenience,
+    # mirroring the Express setup used previously.
+    path('login/', auth_views.LoginView.as_view(), name='login-direct'),
     path('api/pdf/', include('pdfconvert.urls')),
     path('api/ocr/', include('ocr.urls')),
     path('profile/', auth_views.ProfileView.as_view(), name='profile'),

--- a/excel_to_json/urls.py
+++ b/excel_to_json/urls.py
@@ -15,16 +15,17 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import path, include, re_path
 from authapp import views as auth_views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', include('api.urls')),
     path('api/auth/', include('authapp.urls')),
-    # Provide a top-level login endpoint for convenience,
-    # mirroring the Express setup used previously.
-    path('login/', auth_views.LoginView.as_view(), name='login-direct'),
+    # Provide a top-level login endpoint for convenience.
+    # Use a regex so `/login` and `/login/` both resolve,
+    # matching the Express implementation more closely.
+    re_path(r'^login/?$', auth_views.LoginView.as_view(), name='login-direct'),
     path('api/pdf/', include('pdfconvert.urls')),
     path('api/ocr/', include('ocr.urls')),
     path('profile/', auth_views.ProfileView.as_view(), name='profile'),


### PR DESCRIPTION
## Summary
- adjust auth endpoint to replicate Express login logic

## Testing
- `python manage.py check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6875793512a48330aa1da5d03e8fdce1